### PR TITLE
fix(security): code scanning alert on Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Lint PR Title
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/skethirajan/ElectroCat/security/code-scanning/1](https://github.com/skethirajan/ElectroCat/security/code-scanning/1)

To address this issue, we will add a `permissions` key to the workflow at the root level. Based on the workflow's purpose (linting PR titles), it only needs read access to the repository content (`contents: read`). No write permissions are required. This ensures that the workflow limits its access to the least privilege necessary for its function.

The fix will be applied near the top of the workflow file, under the `name` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
